### PR TITLE
Remove L3 and Metadata agents

### DIFF
--- a/deployment_tasks.yaml
+++ b/deployment_tasks.yaml
@@ -93,7 +93,7 @@
     timeout: 1800
 
 - id: vmware-dvs-network-agents-l3
-  type: puppet
+  type: skipped
   version: 2.0.0
   groups: ['primary-controller','controller','compute-vmware']
   required_for: [vmware-dvs-network-end]
@@ -109,7 +109,7 @@
     timeout: 1800
 
 - id: vmware-dvs-network-agents-metadata
-  type: puppet
+  type: skipped
   version: 2.0.0
   groups: ['primary-controller','controller','compute-vmware']
   required_for: [vmware-dvs-network-end]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,7 +3,7 @@ name: fuel-plugin-vmware-dvs
 # Human-readable name for your plugin
 title: Neutron VMware DVS ML2 plugin
 # Plugin version
-version: '2.2.2'
+version: '2.2.3'
 # Description
 description: Enable to use plugin vmware_dvs for Neutron
 # Required fuel version


### PR DESCRIPTION
The DVS plugin doesn't need to deploy these when
used with ACI.